### PR TITLE
Display all weekdayLabels

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -296,12 +296,11 @@ class CalendarHeatmap extends React.Component {
     return this.latestProps.weekdayLabels.map((weekdayLabel, dayIndex) => {
       const [x, y] = this.getWeekdayLabelCoordinates(dayIndex);
       const cssClasses = `${this.latestProps.horizontal ? '' : `${CSS_PSEDUO_NAMESPACE}small-text`} ${CSS_PSEDUO_NAMESPACE}weekday-label`;
-      // eslint-disable-next-line no-bitwise
-      return dayIndex & 1 ? (
+      return (
         <text key={`${x}${y}`} x={x} y={y} className={cssClasses}>
           {weekdayLabel}
         </text>
-      ) : null;
+      );
     });
   }
 

--- a/test/CalendarHeatmap.test.jsx
+++ b/test/CalendarHeatmap.test.jsx
@@ -174,7 +174,7 @@ describe('CalendarHeatmap props', () => {
       showWeekdayLabels={true}
     />);
 
-    expect(vertical.find('text.react-calendar-heatmap-small-text')).toHaveLength(3);
+    expect(vertical.find('text.react-calendar-heatmap-small-text')).toHaveLength(7);
   });
 
   it('transformDayElement', () => {


### PR DESCRIPTION
“weekdayLabels" option can specify seven days of the week labels, but in fact only three are displayed.
We sometimes want to display all days of the week labels, so I fixed it.