### PR TITLE
Add showAllWeekdayLabels option to show all weekdays.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "rimraf": "^2.0.0",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.0.0"
+  },
+  "jest": {
+    "testURL": "http://localhost"
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -297,7 +297,7 @@ class CalendarHeatmap extends React.Component {
       const [x, y] = this.getWeekdayLabelCoordinates(dayIndex);
       const cssClasses = `${this.latestProps.horizontal ? '' : `${CSS_PSEDUO_NAMESPACE}small-text`} ${CSS_PSEDUO_NAMESPACE}weekday-label`;
       // eslint-disable-next-line no-bitwise
-      return dayIndex & 1 ? (
+      return this.latestProps.showAllWeekdayLabels || dayIndex & 1 ? (
         <text key={`${x}${y}`} x={x} y={y} className={cssClasses}>
           {weekdayLabel}
         </text>
@@ -333,6 +333,7 @@ CalendarHeatmap.propTypes = {
   horizontal: PropTypes.bool, // whether to orient horizontally or vertically
   showMonthLabels: PropTypes.bool, // whether to show month labels
   showWeekdayLabels: PropTypes.bool, // whether to show weekday labels
+  showAllWeekdayLabels: PropTypes.bool, // whether to show all weekday labels
   showOutOfRangeDays: PropTypes.bool, // whether to render squares for extra days in week after endDate, and before start date
   tooltipDataAttrs: PropTypes.oneOfType([PropTypes.object, PropTypes.func]), // data attributes to add to square for setting 3rd party tooltips, e.g. { 'data-toggle': 'tooltip' } for bootstrap tooltips
   titleForValue: PropTypes.func, // function which returns title text for value
@@ -352,6 +353,7 @@ CalendarHeatmap.defaultProps = {
   horizontal: true,
   showMonthLabels: true,
   showWeekdayLabels: false,
+  showAllWeekdayLabels: false,
   showOutOfRangeDays: false,
   monthLabels: MONTH_LABELS,
   weekdayLabels: DAY_LABELS,

--- a/test/CalendarHeatmap.test.jsx
+++ b/test/CalendarHeatmap.test.jsx
@@ -177,6 +177,28 @@ describe('CalendarHeatmap props', () => {
     expect(vertical.find('text.react-calendar-heatmap-small-text')).toHaveLength(3);
   });
 
+  it('showAllWeekdayLabels true', () => {
+    const calendar = shallow(<CalendarHeatmap
+      startDate={dateNDaysAgo(7)}
+      values={[]}
+      showWeekdayLabels={true}
+      showAllWeekdayLabels={true}
+    />);
+
+    expect(calendar.find('text').length).toEqual(7);
+  });
+
+  it('showAllWeekdayLabels false', () => {
+    const calendar = shallow(<CalendarHeatmap
+      startDate={dateNDaysAgo(7)}
+      values={[]}
+      showWeekdayLabels={true}
+      showAllWeekdayLabels={false}
+    />);
+
+    expect(calendar.find('text').length).toEqual(3);
+  });
+
   it('transformDayElement', () => {
     const transform = rect => React.cloneElement(rect, { 'data-test': 'ok' });
     const today = new Date();


### PR DESCRIPTION
* Fix https://github.com/facebook/jest/issues/6766 jest error (which caused tests to fail)
* Add showAllWeekdayLabels, which defaults to false. If true, every weekday label is displayed
* Add tests for the new feature
* Fixes one issue mentioned in #78 