### PR TITLE
fix bitwise operator rendering every other weekday label

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -302,7 +302,7 @@ class CalendarHeatmap extends React.Component {
         this.props.horizontal ? '' : `${CSS_PSEDUO_NAMESPACE}small-text`
       } ${CSS_PSEDUO_NAMESPACE}weekday-label`;
       // eslint-disable-next-line no-bitwise
-      return dayIndex & 1 ? (
+      return weekdayLabel ? (
         <text key={`${x}${y}`} x={x} y={y} className={cssClasses}>
           {weekdayLabel}
         </text>


### PR DESCRIPTION
Means `weekdayLabels={["Su", "M", "Tu", "W", "Th", "F", "Sa"]}` works