### PR TITLE
fix: indexing issue

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,6 +14,10 @@ export function convertToDate(obj) {
   return obj instanceof Date ? obj : new Date(obj);
 }
 
+export function convertToUtc(date) {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
 export function dateNDaysAgo(numDaysAgo) {
   return shiftDate(new Date(), -numDaysAgo);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
   shiftDate,
   getBeginningTimeForDate,
   convertToDate,
+  convertToUtc,
   getRange,
 } from './helpers';
 
@@ -99,8 +100,10 @@ class CalendarHeatmap extends React.Component {
 
   getValueCache = memoizeOne((props) =>
     props.values.reduce((memo, value) => {
-      const date = convertToDate(value.date);
-      const index = Math.floor((date - this.getStartDateWithEmptyDays()) / MILLISECONDS_IN_ONE_DAY);
+      const utc1 = convertToUtc(convertToDate(value.date));
+      const utc2 = convertToUtc(this.getStartDateWithEmptyDays());
+      const index = Math.floor((utc1 - utc2) / MILLISECONDS_IN_ONE_DAY);
+
       // eslint-disable-next-line no-param-reassign
       memo[index] = {
         value,


### PR DESCRIPTION
Converting to UTC before calculating with milliseconds seems to fix the indexing issue. See https://stackoverflow.com/a/15289883. Before this I would get one of my indexes overwritten by a DST issue or something and the date would simply disappear. This can also be used in the `getDateDifferenceInDays()` function.

closes https://github.com/kevinsqi/react-calendar-heatmap/issues/100